### PR TITLE
feat: add payment methods for woocommerce block checkout

### DIFF
--- a/classes/TwikeyLinkPaymentMethodType.php
+++ b/classes/TwikeyLinkPaymentMethodType.php
@@ -1,0 +1,41 @@
+<?php
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+class TwikeyLinkPaymentMethodType extends AbstractPaymentMethodType
+{
+    protected $name = 'twikey-paylink';
+
+    public function initialize() {
+        $this->settings = get_option( 'woocommerce_twikey-paylink_settings', [] );
+    }
+
+    public function is_active() {
+        return filter_var( $this->get_setting( 'enabled', false ), FILTER_VALIDATE_BOOLEAN );
+    }
+
+    public function get_payment_method_script_handles() {
+        wp_register_script(
+            'twikey-link-payment-method',
+            plugins_url('../resources/twikey-link-payment-method.js', __FILE__),
+            ['wc-settings', 'wc-blocks-registry', 'wp-element'],
+            // Use file modification time to ensure cache busting when the file changes
+            filemtime(plugin_dir_path(__FILE__) . '../resources/twikey-link-payment-method.js') ?: '1.0.0',
+            true
+        );
+
+        return [ 'twikey-link-payment-method' ];
+    }
+
+    public function get_payment_method_script_handles_for_admin() {
+        return $this->get_payment_method_script_handles();
+    }
+
+    public function get_payment_method_data() {
+        return [
+            'title'       => $this->get_setting('title', __('Twikey Payment Gateway', 'twikey')),
+            'description' => $this->get_setting('description'),
+            'supports'    => $this->get_supported_features(),
+        ];
+    }
+}

--- a/classes/TwikeyLoader.php
+++ b/classes/TwikeyLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+
 class TwikeyLoader {
 
     private static $log;
@@ -8,9 +10,14 @@ class TwikeyLoader {
         require_once dirname(__FILE__) . '/Twikey.php';
         require_once dirname(__FILE__) . '/TwikeyGateway.php';
         require_once dirname(__FILE__) . '/TwikeyLinkGateway.php';
+        require_once dirname(__FILE__) . '/TwikeyPaymentMethodType.php';
+        require_once dirname(__FILE__) . '/TwikeyLinkPaymentMethodType.php';
+
 
         add_filter('woocommerce_payment_gateways'  , array(__CLASS__, 'addTwikeyGateways'));
         add_filter('woocommerce_order_actions', array( __CLASS__, 'add_verify_order_action' ));
+        add_action('woocommerce_blocks_payment_method_type_registration', array( __CLASS__, 'addTwikeyPaymentMethods' ) );
+
         //add_filter('woocommerce_available_payment_gateways', array( __CLASS__, 'filter_gateways' ), 1);
         //add_filter('twikey_gateway_selection', array( __CLASS__, 'selectGatewayBasedOnCart') );
         //add_filter('twikey_template_selection', array( __CLASS__, 'selectCtBasedOnOrder') );
@@ -20,6 +27,12 @@ class TwikeyLoader {
         $methods[] = 'TwikeyGateway';
         $methods[] = 'TwikeyLinkGateway';
         return $methods;
+    }
+
+    public static function addTwikeyPaymentMethods( PaymentMethodRegistry $paymentMethodRegistry)
+    {
+        $paymentMethodRegistry->register( new TwikeyPaymentMethodType() );
+        $paymentMethodRegistry->register( new TwikeyLinkPaymentMethodType() );
     }
 
     public static function add_verify_order_action( $actions ) {

--- a/classes/TwikeyPaymentMethodType.php
+++ b/classes/TwikeyPaymentMethodType.php
@@ -1,0 +1,40 @@
+<?php
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+class TwikeyPaymentMethodType extends AbstractPaymentMethodType
+{
+    protected $name = 'twikey';
+
+    public function initialize() {
+        $this->settings = get_option( 'woocommerce_twikey_settings', [] );
+    }
+
+    public function is_active() {
+        return filter_var( $this->get_setting( 'enabled', false ), FILTER_VALIDATE_BOOLEAN );
+    }
+
+    public function get_payment_method_script_handles() {
+        wp_register_script(
+            'twikey-payment-method',
+            plugins_url('../resources/twikey-payment-method.js', __FILE__),
+            ['wc-settings', 'wc-blocks-registry', 'wp-element'],
+            // Use file modification time to ensure cache busting when the file changes
+            filemtime(plugin_dir_path(__FILE__) . '../resources/twikey-payment-method.js') ?: '1.0.0',
+            true
+        );
+        return [ 'twikey-payment-method' ];
+    }
+
+    public function get_payment_method_script_handles_for_admin() {
+        return $this->get_payment_method_script_handles();
+    }
+
+    public function get_payment_method_data() {
+        return [
+            'title'       => $this->get_setting('title', 'Twikey'),
+            'description' => $this->get_setting('description'),
+            'supports'    => $this->get_supported_features(),
+        ];
+    }
+}

--- a/resources/twikey-link-payment-method.js
+++ b/resources/twikey-link-payment-method.js
@@ -1,0 +1,40 @@
+{
+  const { getSetting } = window.wc.wcSettings;
+  const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
+  const { createElement } = window.wp.element;
+
+  const settings = getSetting('twikey-paylink_data')
+
+  const Label = () => {
+    return createElement('span', {
+      style: { display: 'flex', alignItems: 'center', gap: '8px' }
+    }, [
+      settings.title,
+      createElement(
+        'img',
+        {
+          src: 'https://www.twikey.com/img/butterfly.svg',
+          alt: 'Twikey Logo',
+          style: { height: '1em', display: 'inline' }
+        })
+    ])
+  }
+
+  const Content = () => {
+    return createElement('div', null, settings.description);
+  }
+
+  registerPaymentMethod({
+    name: 'twikey-paylink',
+    title: settings.title,
+    description: settings.description,
+    label: createElement(Label),
+    ariaLabel: settings.title,
+    content: createElement(Content),
+    edit: createElement(Content),
+    canMakePayment: (options) => true,
+    supports: {
+      features: settings.supports,
+    }
+  })
+}

--- a/resources/twikey-payment-method.js
+++ b/resources/twikey-payment-method.js
@@ -1,0 +1,40 @@
+{
+  const { getSetting } = window.wc.wcSettings;
+  const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
+  const { createElement } = window.wp.element;
+
+  const settings = getSetting('twikey_data')
+
+  const Label = () => {
+    return createElement('span', {
+      style: { display: 'flex', alignItems: 'center', gap: '8px' }
+    }, [
+      settings.title,
+      createElement(
+        'img',
+        {
+          src: 'https://www.twikey.com/img/butterfly.svg',
+          alt: 'Twikey Logo',
+          style: { height: '1em', display: 'inline' }
+        })
+    ])
+  }
+
+  const Content = () => {
+    return createElement('div', null, settings.description);
+  }
+
+  registerPaymentMethod({
+    name: 'twikey',
+    title: settings.title,
+    description: settings.description,
+    label: createElement(Label),
+    ariaLabel: settings.title,
+    content: createElement(Content),
+    edit: createElement(Content),
+    canMakePayment: (options) => true,
+    supports: {
+      features: settings.supports,
+    }
+  })
+}


### PR DESCRIPTION
This pull request adds support for WooCommerce Blocks (the new checkout/cart experience) for Twikey payment methods. It introduces new PHP classes to register Twikey payment methods with WooCommerce Blocks, and adds corresponding JavaScript files to integrate these payment methods into the frontend block-based checkout.